### PR TITLE
Add configurable timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ We'll be covering the majority of the commands in this guide. Here is a brief de
     -   `config`: Output the generated Marathon json application definition for the RMF.
     -   `install`: Install the RMF as a Marathon app.
     -   `uninstall`: Delete the RMF from Marathon.
-    -   `wait-for-service`: Waits until the framework's HTTP API returns OK.
+    -   `wait-for-service`: Waits timeout seconds (default is 60) until the framework's HTTP API returns OK.
     -   `clean-metadata`: Removes Zookeeper metadata stored by the RMF instance.
     -   `teardown`: Issues a teardown call to the Mesos master, killing all tasks related to the RMF instance.
 -   `riak-mesos cluster`

--- a/riak_mesos/cli.py
+++ b/riak_mesos/cli.py
@@ -101,6 +101,9 @@ class RiakMesosCli(object):
                                                             '--bucket-type',
                                                             'default')
         cli_args, self.args['props'] = extract_option(cli_args, '--props', '')
+        cli_args, timeout = extract_option(cli_args, '--timeout',
+                                           '60', 'integer')
+        self.args['timeout'] = int(timeout)
         cli_args, num_nodes = extract_option(cli_args, '--nodes', '1',
                                              'integer')
         self.args['num_nodes'] = int(num_nodes)

--- a/riak_mesos/constants.py
+++ b/riak_mesos/constants.py
@@ -28,7 +28,7 @@ Subcommands:
     framework config
     framework install
     framework status
-    framework wait-for-service
+    framework wait-for-service [--timeout <seconds>]
     framework clean-metadata
     framework teardown
     framework uninstall
@@ -38,7 +38,7 @@ Subcommands:
     cluster config advanced [--file]
     cluster list [--json]
     cluster create
-    cluster wait-for-service
+    cluster wait-for-service [--timeout <seconds>]
     cluster endpoints
     cluster restart
     cluster destroy
@@ -53,12 +53,12 @@ Subcommands:
     node list [--json]
     node remove --node <name> [--force]
     node add [--nodes <number>]
-    node wait-for-service [--node <name>]
+    node wait-for-service [--node <name>] [--timeout <seconds>]
     director config
     director install
     director uninstall
     director endpoints
-    director wait-for-service
+    director wait-for-service [--timeout <seconds>]
 
 Options (available on most commands):
     --config <json-file> (/etc/riak-mesos/config.json)
@@ -97,7 +97,8 @@ help_dict = {
     'framework install':
     ('Generates and installs a marathon app for the framework'),
     'framework wait-for-service':
-    ('Waits 60 seconds or until Framework is running'),
+    ('Waits timeout seconds (default is 60) or until Framework is running. '
+     'Specify timeout with --timeout.'),
     'framework endpoints': ('Retrieves useful endpoints for the framework.'),
     'cluster info':
     ('Gets current metadata about a cluster.'),
@@ -112,7 +113,9 @@ help_dict = {
     ('Creates a new cluster. Specify the name with --cluster (default is '
      'default).'),
     'cluster wait-for-service':
-    ('Iterates over all nodes in cluster and executes node wait-for-service.'),
+    ('Iterates over all nodes in cluster and executes node wait-for-service. '
+     'Optionally waits until the number of nodes (specified by --nodes) at '
+     'minimum are joined to the cluster.'),
     'cluster endpoints':
     ('Iterates over all nodes in cluster and prints connection information.'),
     'cluster restart':
@@ -130,7 +133,9 @@ help_dict = {
     'node add':
     ('Adds one or more (using --nodes) nodes to a --cluster (default is '
      'default).'),
-    'node wait-for-service': ('Waits 20 seconds or until node is running'),
+    'node wait-for-service':
+    ('Waits timeout seconds (default is 60) or until node is running. '
+     'Specify timeout with --timeout.'),
     'node remove':
     ('Removes a node from the cluster, specify node id with --node'),
     'node aae-status':

--- a/tests/end_to_end/test_framework.py
+++ b/tests/end_to_end/test_framework.py
@@ -9,7 +9,7 @@ def test_framework_install():
     assert o.strip() == b'Finished adding riak to marathon.'
     assert c == 0
     assert e == b''
-    c, o, e = _fc(['framework', 'wait-for-service'])
+    c, o, e = _fc(['framework', 'wait-for-service', '--timeout', '600'])
     assert o.strip() == b'Riak Mesos Framework is ready.'
     assert c == 0
     assert e == b''
@@ -47,13 +47,16 @@ def test_node_list_add():
         assert o.strip() == expect1 or o.strip() == expect2
         assert c == 0
         assert e == b''
-    c, o, e = _fc(['node', 'wait-for-service', '--node', 'riak-default-1'])
+    c, o, e = _fc(['node', 'wait-for-service', '--node', 'riak-default-1',
+                   '--timeout', '600'])
     assert c == 0
     assert e == ''
-    c, o, e = _fc(['node', 'wait-for-service', '--node', 'riak-default-2'])
+    c, o, e = _fc(['node', 'wait-for-service', '--node', 'riak-default-2',
+                   '--timeout', '600'])
     assert c == 0
     assert e == ''
-    c, o, e = _fc(['cluster', 'wait-for-service'])
+    c, o, e = _fc(['cluster', 'wait-for-service',
+                   '--timeout', '600', '--nodes', '2'])
     expect1 = b'''Node riak-default-1 is ready.
 Node riak-default-2 is ready.'''
     expect2 = b'''Node riak-default-2 is ready.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This script can be run under Docker like this, from the top-level riak-mesos-tools directory,
+# given a config file with proper URLs for artifacts:
+#
+# docker run --rm -t --dns <MESOS_DNS> -v $(pwd)/config.json:/tmp/config.json \
+# -v $(pwd)/tests/run-tests.sh:/root/run-tests.sh -v $(pwd):/tmp/riak-mesos-tools \
+# basho/build-essential-mesos:14.04-0.26 /root/run-tests.sh
+#
+# TODO Once artifacts are publicly published, add option to run this without an external
+#      config file, use a standard config file (using Riak KV OSS, of course)
+
+mkdir -p /etc/riak-mesos
+
+# Because Docker has issues placing files in directories that don't
+# exist using volumes, copy it in place
+if [ -e /tmp/config.json ]; then
+    cp /tmp/config.json /etc/riak-mesos
+fi
+
+apt-get install -y python-pip
+cd /root
+
+# Local copies of test code can be mounted as a volume
+# But since the build process tries doing hard links, it doesn't work
+# as a volume, so copy it into place
+if [ -d /tmp/riak-mesos-tools ]; then
+    cp -ar /tmp/riak-mesos-tools /root
+# If none is mounted, check out from git
+else
+   git clone --branch 0.4.1 --depth 1 https://github.com/basho-labs/riak-mesos-tools.git
+fi
+
+cd riak-mesos-tools
+make test-end-to-end


### PR DESCRIPTION
Add a timeout parameter to the framework, node, and cluster wait-for-service commands with a default value of 60s if not specified.

Add a --nodes parameter to the cluster wait-for-service command to wait for the specified number of nodes to reach the "valid" state.

Added a shell script that is used for running the tests in Docker.