### PR TITLE
Add field for actual patches .tar.gz

### DIFF
--- a/config/config.example.json
+++ b/config/config.example.json
@@ -30,7 +30,8 @@
         },
         "node": {
             "url": "http://riak-tools.s3.amazonaws.com/riak/2.1/2.1.3/ubuntu/trusty/riak-2.1.3-amd64.tar.gz",
-            "patches-url": "https://github.com/basho-labs/riak_explorer/releases/download/0.2.0/riak_explorer-0.2.0.patch-ubuntu-trusty-amd64.tar.gz",
+            "explorer-url": "https://github.com/basho-labs/riak_explorer/releases/download/0.2.0/riak_explorer-0.2.0.patch-ubuntu-trusty-amd64.tar.gz",
+            "patches-url": "",
             "cpus": 1.0,
             "mem": 8000.0,
             "disk": 20000.0

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -24,14 +24,14 @@
             "constraints": [["hostname", "UNIQUE"]]
         },
         "executor": {
-            "url": "https://github.com/basho-labs/riak-mesos-executor/releases/download/0.2.1/riak_mesos_executor-0.2.1-ubuntu-trusty-amd64.tar.gz",
+            "url": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.0-beta4/riak_mesos_executor-1.0-beta4-ubuntu-trusty-amd64.tar.gz",
             "cpus": 0.1,
             "mem": 512.0
         },
         "node": {
             "url": "http://riak-tools.s3.amazonaws.com/riak/2.1/2.1.3/ubuntu/trusty/riak-2.1.3-amd64.tar.gz",
             "explorer-url": "https://github.com/basho-labs/riak_explorer/releases/download/0.2.0/riak_explorer-0.2.0.patch-ubuntu-trusty-amd64.tar.gz",
-            "patches-url": "",
+            "patches-url": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.0-beta4/riak_erlpmd_patches-1.0-beta4-ubuntu-trusty-amd64.tar.gz",
             "cpus": 1.0,
             "mem": 8000.0,
             "disk": 20000.0

--- a/config/config.template.json
+++ b/config/config.template.json
@@ -30,7 +30,8 @@
         },
         "node": {
             "url": "{{node_url}}",
-            "patches-url": "{{explorer_url}}",
+            "patches-url": "{{patches_url}}",
+            "explorer-url": "{{explorer_url}}",
             "cpus": 1.0,
             "mem": 8000.0,
             "disk": 20000.0

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -48,6 +48,8 @@ class RiakMesosConfig(object):
         mj['env']['RIAK_MESOS_ZK'] = self.get('zk')
         mj['env']['RIAK_MESOS_MASTER'] = self.get('master')
         mj['env']['RIAK_MESOS_USER'] = self.get('user')
+        mj['env']['RIAK_MESOS_SCHEDULER_PKG'] = self.get(
+            'scheduler', 'url').rsplit('/', 1)[-1]
         mj['env']['RIAK_MESOS_EXECUTOR_PKG'] = self.get(
             'executor', 'url').rsplit('/', 1)[-1]
         mj['env']['RIAK_MESOS_RIAK_PKG'] = self.get(

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -52,7 +52,7 @@ class RiakMesosConfig(object):
             'executor', 'url').rsplit('/', 1)[-1]
         mj['env']['RIAK_MESOS_RIAK_PKG'] = self.get(
             'node', 'url').rsplit('/', 1)[-1]
-        mj['env']['RIAK_ERLPMD_PATCHES_PKG'] = self.get(
+        mj['env']['RIAK_MESOS_PATCHES_PKG'] = self.get(
             'node', 'patches-url').rsplit('/', 1)[-1]
         mj['env']['RIAK_MESOS_EXPLORER_PKG'] = self.get(
             'node', 'explorer-url').rsplit('/', 1)[-1]

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -48,6 +48,14 @@ class RiakMesosConfig(object):
         mj['env']['RIAK_MESOS_ZK'] = self.get('zk')
         mj['env']['RIAK_MESOS_MASTER'] = self.get('master')
         mj['env']['RIAK_MESOS_USER'] = self.get('user')
+        mj['env']['RIAK_MESOS_EXECUTOR_PKG'] = self.get(
+            'executor', 'url').rsplit('/', 1)[-1]
+        mj['env']['RIAK_MESOS_RIAK_PKG'] = self.get(
+            'node', 'url').rsplit('/', 1)[-1]
+        mj['env']['RIAK_ERLPMD_PATCHES_PKG'] = self.get(
+            'node', 'patches-url').rsplit('/', 1)[-1]
+        mj['env']['RIAK_MESOS_EXPLORER_PKG'] = self.get(
+            'node', 'explorer-url').rsplit('/', 1)[-1]
         if self.get('scheduler', 'constraints') != '':
             mj['env']['RIAK_MESOS_CONSTRAINTS'] = json.dumps(
                 self.get('scheduler', 'constraints'))

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -39,6 +39,7 @@ class RiakMesosConfig(object):
         mj['uris'].append(self.get('executor', 'url'))
         mj['uris'].append(self.get('node', 'url'))
         mj['uris'].append(self.get('node', 'patches-url'))
+        mj['uris'].append(self.get('node', 'explorer-url'))
         mj['cmd'] = './riak_mesos_scheduler/bin/ermf-scheduler'
         if self.get('constraints') != '':
             mj['constraints'] = self.get('constraints')

--- a/tests/end_to_end/test_framework.py
+++ b/tests/end_to_end/test_framework.py
@@ -58,9 +58,11 @@ def test_node_list_add():
     c, o, e = _fc(['cluster', 'wait-for-service',
                    '--timeout', '600', '--nodes', '2'])
     expect1 = b'''Node riak-default-1 is ready.
-Node riak-default-2 is ready.'''
+Node riak-default-2 is ready.
+Cluster default is ready.'''
     expect2 = b'''Node riak-default-2 is ready.
-Node riak-default-1 is ready.'''
+Node riak-default-1 is ready.
+Cluster default is ready.'''
     assert o.strip() == expect1 or o.strip() == expect2
     assert c == 0
     assert e == b''


### PR DESCRIPTION
 - Move `riak_explorer` archive to `"explorer-url"`
 - Use `"patches-url"` for the real patches archive

NB This represents a breaking change: configuration files will need updating to use this version.