### PR TITLE
Use 'fetch' instead of 'uris'

### DIFF
--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -34,12 +34,12 @@ class RiakMesosConfig(object):
         mj['cpus'] = self.get('scheduler', 'cpus')
         mj['mem'] = self.get('scheduler', 'mem')
         mj['ports'] = [0]
-        mj['uris'] = []
-        mj['uris'].append(self.get('scheduler', 'url'))
-        mj['uris'].append(self.get('executor', 'url'))
-        mj['uris'].append(self.get('node', 'url'))
-        mj['uris'].append(self.get('node', 'patches-url'))
-        mj['uris'].append(self.get('node', 'explorer-url'))
+        mj['fetch'] = []
+        mj['fetch'].append({ 'uri': self.get('scheduler', 'url')})
+        mj['fetch'].append({ 'uri': self.get('executor', 'url'), 'extract': false })
+        mj['fetch'].append({ 'uri': self.get('node', 'url'), 'extract': false })
+        mj['fetch'].append({ 'uri': self.get('node', 'patches-url'), 'extract': false })
+        mj['fetch'].append({ 'uri': self.get('node', 'explorer-url'), 'extract': false })
         mj['cmd'] = './riak_mesos_scheduler/bin/ermf-scheduler'
         if self.get('constraints') != '':
             mj['constraints'] = self.get('constraints')

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -121,7 +121,7 @@ class RiakMesosConfig(object):
                 'DIRECTOR_FRAMEWORK': self.get('framework-name'),
                 'DIRECTOR_CLUSTER': cluster
             },
-            'uris': [self.get('director', 'url')],
+            'fetch': [{'uri': self.get('director', 'url')}],
             'healthChecks': [
                 {
                     'protocol': 'HTTP',

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -40,7 +40,7 @@ class RiakMesosConfig(object):
         mj['fetch'].append({ 'uri': self.get('node', 'url'), 'extract': false })
         mj['fetch'].append({ 'uri': self.get('node', 'patches-url'), 'extract': false })
         mj['fetch'].append({ 'uri': self.get('node', 'explorer-url'), 'extract': false })
-        mj['cmd'] = './riak_mesos_scheduler/bin/ermf-scheduler'
+        mj['cmd'] = './bin/ermf-scheduler'
         if self.get('constraints') != '':
             mj['constraints'] = self.get('constraints')
         mj['env'] = {}

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -36,10 +36,10 @@ class RiakMesosConfig(object):
         mj['ports'] = [0]
         mj['fetch'] = []
         mj['fetch'].append({ 'uri': self.get('scheduler', 'url')})
-        mj['fetch'].append({ 'uri': self.get('executor', 'url'), 'extract': false })
-        mj['fetch'].append({ 'uri': self.get('node', 'url'), 'extract': false })
-        mj['fetch'].append({ 'uri': self.get('node', 'patches-url'), 'extract': false })
-        mj['fetch'].append({ 'uri': self.get('node', 'explorer-url'), 'extract': false })
+        mj['fetch'].append({ 'uri': self.get('executor', 'url'), 'extract': False })
+        mj['fetch'].append({ 'uri': self.get('node', 'url'), 'extract': False })
+        mj['fetch'].append({ 'uri': self.get('node', 'patches-url'), 'extract': False })
+        mj['fetch'].append({ 'uri': self.get('node', 'explorer-url'), 'extract': False })
         mj['cmd'] = './bin/ermf-scheduler'
         if self.get('constraints') != '':
             mj['constraints'] = self.get('constraints')


### PR DESCRIPTION
According to [marathon docs](https://mesosphere.github.io/marathon/docs/rest-api.html) 'uris' has been deprecated since marathon v0.15.0, replaced with 'fetch' which allows not extracting specific archives.