### PR TITLE
Add optional field .riak.node.network_interface_name

### DIFF
--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -86,6 +86,7 @@ class RiakMesosConfig(object):
                         'RIAK_MESOS_EXECUTOR_CPUS', conf)
         self._from_conf('executor', 'mem',
                         'RIAK_MESOS_EXECUTOR_MEM', conf)
+        self._from_conf('node', 'network_interface_name', 'RIAK_MESOS_NODE_IFACE', conf)
         self._from_conf('node', 'cpus', 'RIAK_MESOS_NODE_CPUS', conf)
         self._from_conf('node', 'mem', 'RIAK_MESOS_NODE_MEM', conf)
         self._from_conf('node', 'disk', 'RIAK_MESOS_NODE_DISK', conf)
@@ -171,6 +172,8 @@ class RiakMesosConfig(object):
         if self.get('failover-timeout') != '':
             mj['env']['RIAK_MESOS_FAILOVER_TIMEOUT'] = str(self.get(
                 'failover-timeout'))
+        if self.get('node', 'network_interface_name') != '':
+            mj['env']['RIAK_MESOS_NODE_IFACE'] = str(self.get('node', 'network_interface_name'))
         if self.get('node', 'cpus') != '':
             mj['env']['RIAK_MESOS_NODE_CPUS'] = str(self.get('node', 'cpus'))
         if self.get('node', 'mem') != '':

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -86,7 +86,8 @@ class RiakMesosConfig(object):
                         'RIAK_MESOS_EXECUTOR_CPUS', conf)
         self._from_conf('executor', 'mem',
                         'RIAK_MESOS_EXECUTOR_MEM', conf)
-        self._from_conf('node', 'network_interface_name', 'RIAK_MESOS_NODE_IFACE', conf)
+        self._from_conf('node', 'network_interface_name',
+                        'RIAK_MESOS_NODE_IFACE', conf)
         self._from_conf('node', 'cpus', 'RIAK_MESOS_NODE_CPUS', conf)
         self._from_conf('node', 'mem', 'RIAK_MESOS_NODE_MEM', conf)
         self._from_conf('node', 'disk', 'RIAK_MESOS_NODE_DISK', conf)

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -173,7 +173,8 @@ class RiakMesosConfig(object):
             mj['env']['RIAK_MESOS_FAILOVER_TIMEOUT'] = str(self.get(
                 'failover-timeout'))
         if self.get('node', 'network_interface_name') != '':
-            mj['env']['RIAK_MESOS_NODE_IFACE'] = str(self.get('node', 'network_interface_name'))
+            mj['env']['RIAK_MESOS_NODE_IFACE'] = \
+                    str(self.get('node', 'network_interface_name'))
         if self.get('node', 'cpus') != '':
             mj['env']['RIAK_MESOS_NODE_CPUS'] = str(self.get('node', 'cpus'))
         if self.get('node', 'mem') != '':
@@ -254,7 +255,7 @@ class RiakMesosConfig(object):
             if (key in self._config and subkey1 in self._config[key] and
                     subkey2 in self._config[key][subkey1]):
                 return self._config[key][subkey1][subkey2]
-        if key in self._config and subkey1 in self._config[key]:
+        elif key in self._config and subkey1 in self._config[key]:
             return self._config[key][subkey1]
         return ''
 


### PR DESCRIPTION
This PR corresponds to basho-labs/riak-mesos-executor#26

Optionally allow the operator to set `.riak.node.network_interface_name` and pass it to the scheduler as env var `RIAK_MESOS_NODE_IFACE`.

Also fix a little bug-ette in `RiakMesosConfig.get_any(...)` where it would return the parent object if the child specified did not exist.