### PR TITLE
Cluster riak config management

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,12 @@ Other useful information can be found by executing these commands:
     riak-mesos node ringready --node riak-default-1
     riak-mesos node transfers --node riak-default-1
 
-Update the Cluster Configuration
---------------------------------
+Cluster Configuration
+---------------------
 
-You can customize the `riak.conf` and `advanced.config` for a cluster if necessary. Use [riak-mesos-scheduler/master/priv/riak.conf.default](https://raw.githubusercontent.com/basho-labs/riak-mesos-scheduler/master/priv/riak.conf.default) and [riak-mesos-scheduler/master/priv/advanced.config.default](https://raw.githubusercontent.com/basho-labs/riak-mesos-scheduler/master/priv/advanced.config.default) as templates. It is important that all of the values specified with `{{...}}` remain intact.
+By default, the Riak-Mesos Framework will use the config file that ships with the Riak archive you install, plus some automated modifications. However, you can customize the `riak.conf` and `advanced.config` for a cluster if necessary. Use [riak-mesos/master/docs/riak.conf.default](https://raw.githubusercontent.com/basho-labs/riak-mesos/master/docs/riak.conf.default) and [riak-mesos/master/docs/advanced.config.default](https://raw.githubusercontent.com/basho-labs/riak-mesos/master/docs/advanced.config.default) as templates.
+
+It is important to note that [certain configuration items](#executor-config-template-variables) cannot be customised. Their values are controlled by the executor, as is required to allow operation within Mesos.
 
 Once you have created your customized versions of these files, you can save them to the cluster using the following commands:
 
@@ -284,6 +286,23 @@ Similarly the advanced.config can be updated like so:
     riak-mesos cluster config-advanced --file /path/to/your/advanced.config
 
 **Note:** If you already have nodes running in a cluster, you'll need to perform a `riak-mesos cluster restart` to force the cluster to pick up the new changes.
+
+Executor Config Template Variables
+----------------------------------
+
+The following template variables are used when modifying the Riak config template, upon creating a node in a cluster:
+
+| Variable                 | Meaning             |
+| ------------------------ | ------------------- |
+| `fullyqualifiednodename` | Riak nodename       |
+| `handoffport`            | Handoff Port        |
+| `disterlport`            | Erlang distribution |
+| `httpport`               | HTTP Port           |
+| `pbport`                 | Protobuf Port       |
+| `cepmdport`              | EPMD Port           |
+| `data_dir`               | Riak Data dir       |
+| `bindaddress`            | Network bind addr   |
+
 
 Restart the Cluster
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -340,16 +340,22 @@ Other useful information can be found by executing these commands:
     riak-mesos node ringready --node riak-default-1
     riak-mesos node transfers --node riak-default-1
 
-Update the Cluster Configuration
---------------------------------
+Cluster Configuration
+---------------------
 
-You can customize the ``riak.conf`` and ``advanced.config`` for a
-cluster if necessary. Use
-`riak-mesos-scheduler/master/priv/riak.conf.default <https://raw.githubusercontent.com/basho-labs/riak-mesos-scheduler/master/priv/riak.conf.default>`__
+By default, the Riak-Mesos Framework will use the config file that ships
+with the Riak archive you install, plus some automated modifications.
+However, you can customize the ``riak.conf`` and ``advanced.config`` for
+a cluster if necessary. Use
+`riak-mesos/master/docs/riak.conf.default <https://raw.githubusercontent.com/basho-labs/riak-mesos/master/docs/riak.conf.default>`__
 and
-`riak-mesos-scheduler/master/priv/advanced.config.default <https://raw.githubusercontent.com/basho-labs/riak-mesos-scheduler/master/priv/advanced.config.default>`__
-as templates. It is important that all of the values specified with
-``{{...}}`` remain intact.
+`riak-mesos/master/docs/advanced.config.default <https://raw.githubusercontent.com/basho-labs/riak-mesos/master/docs/advanced.config.default>`__
+as templates.
+
+It is important to note that `certain configuration
+items <#executor-config-template-variables>`__ cannot be customised.
+Their values are controlled by the executor, as is required to allow
+operation within Mesos.
 
 Once you have created your customized versions of these files, you can
 save them to the cluster using the following commands:
@@ -376,6 +382,32 @@ Similarly the advanced.config can be updated like so:
 **Note:** If you already have nodes running in a cluster, you'll need to
 perform a ``riak-mesos cluster restart`` to force the cluster to pick up
 the new changes.
+
+Executor Config Template Variables
+----------------------------------
+
+The following template variables are used when modifying the Riak config
+template, upon creating a node in a cluster:
+
++------------------------------+-----------------------+
+| Variable                     | Meaning               |
++==============================+=======================+
+| ``fullyqualifiednodename``   | Riak nodename         |
++------------------------------+-----------------------+
+| ``handoffport``              | Handoff Port          |
++------------------------------+-----------------------+
+| ``disterlport``              | Erlang distribution   |
++------------------------------+-----------------------+
+| ``httpport``                 | HTTP Port             |
++------------------------------+-----------------------+
+| ``pbport``                   | Protobuf Port         |
++------------------------------+-----------------------+
+| ``cepmdport``                | EPMD Port             |
++------------------------------+-----------------------+
+| ``data_dir``                 | Riak Data dir         |
++------------------------------+-----------------------+
+| ``bindaddress``              | Network bind addr     |
++------------------------------+-----------------------+
 
 Restart the Cluster
 -------------------

--- a/riak_mesos/commands/cmd_cluster.py
+++ b/riak_mesos/commands/cmd_cluster.py
@@ -98,8 +98,11 @@ def config(ctx, delete, riak_file, **kwargs):
     ctx.init_args(**kwargs)
     url = 'clusters/' + ctx.cluster + '/config'
     if delete:
-        r = ctx.api_request('delete', url)
-        click.echo(r.text)
+        r = ctx.api_request('delete', url, headers={'Accept': '*/*'}, data='')
+        if r.status_code == 404:
+            click.echo('No riak.conf set for cluster ' + ctx.cluster)
+        else:
+            click.echo(r.text)
     elif riak_file is None:
         r = ctx.api_request('get', url, headers={'Accept': '*/*'})
         if r.status_code == 404:
@@ -131,8 +134,11 @@ def config_advanced(ctx, delete, advanced_file, **kwargs):
     ctx.init_args(**kwargs)
     url = 'clusters/' + ctx.cluster + '/advancedConfig'
     if delete:
-        r = ctx.api_request('delete', url)
-        click.echo(r.text)
+        r = ctx.api_request('delete', url, headers={'Accept': '*/*'}, data='')
+        if r.status_code == 404:
+            click.echo('No advanced.config set for cluster ' + ctx.cluster)
+        else:
+            click.echo(r.text)
     elif advanced_file is None:
         r = ctx.api_request('get', url,
                             headers={'Accept': '*/*'})

--- a/riak_mesos/commands/cmd_cluster.py
+++ b/riak_mesos/commands/cmd_cluster.py
@@ -102,7 +102,10 @@ def config(ctx, delete, riak_file, **kwargs):
         click.echo(r.text)
     elif riak_file is None:
         r = ctx.api_request('get', url, headers={'Accept': '*/*'})
-        click.echo(r.text)
+        if r.status_code == 404:
+            click.echo('No riak.conf set for cluster ' + ctx.cluster)
+        else:
+            click.echo(r.text)
     else:
         with open(riak_file) as data_file:
             payload = data_file.read()
@@ -133,7 +136,10 @@ def config_advanced(ctx, delete, advanced_file, **kwargs):
     elif advanced_file is None:
         r = ctx.api_request('get', url,
                             headers={'Accept': '*/*'})
-        click.echo(r.text)
+        if r.status_code == 404:
+            click.echo('No advanced.config set for cluster ' + ctx.cluster)
+        else:
+            click.echo(r.text)
     else:
         with open(advanced_file) as data_file:
             payload = data_file.read()

--- a/riak_mesos/commands/cmd_cluster.py
+++ b/riak_mesos/commands/cmd_cluster.py
@@ -85,26 +85,29 @@ def info(ctx, **kwargs):
 
 
 @cli.command()
+@click.option('-d', '--delete', is_flag=True,
+              help='Delete the cluster\'s riak.conf file.')
 @click.option('--file', 'riak_file',
               type=click.Path(exists=True, file_okay=True,
                               resolve_path=True),
               help='Cluster riak.conf file to save.')
 @pass_context
-def config(ctx, riak_file, **kwargs):
+def config(ctx, delete, riak_file, **kwargs):
     """Gets or sets the riak.conf configuration for a cluster, specify cluster
     id with --cluster and config file location with --file"""
     ctx.init_args(**kwargs)
-    if riak_file is None:
-        r = ctx.api_request('get', 'clusters/' +
-                            ctx.cluster + '/config',
-                            headers={'Accept': '*/*'})
+    url = 'clusters/' + ctx.cluster + '/config'
+    if delete:
+        r = ctx.api_request('delete', url)
+        click.echo(r.text)
+    elif riak_file is None:
+        r = ctx.api_request('get', url, headers={'Accept': '*/*'})
         click.echo(r.text)
     else:
         with open(riak_file) as data_file:
             payload = data_file.read()
             r = ctx.api_request(
-                'put', 'clusters/' +
-                ctx.cluster + '/config',
+                'put', url,
                 data=payload,
                 headers={'Accept': '*/*',
                          'Content-Type': 'plain/text'})
@@ -112,18 +115,23 @@ def config(ctx, riak_file, **kwargs):
 
 
 @cli.command('config-advanced')
+@click.option('-d', '--delete', is_flag=True,
+              help='Delete the cluster\'s advanced.config file.')
 @click.option('--file', 'advanced_file',
               type=click.Path(exists=True, file_okay=True,
                               resolve_path=True),
               help='Cluster advanced.config file to save.')
 @pass_context
-def config_advanced(ctx, advanced_file, **kwargs):
+def config_advanced(ctx, delete, advanced_file, **kwargs):
     """Gets or sets the advanced.config configuration for a cluster, specify
     cluster id with --cluster and config file location with --file"""
     ctx.init_args(**kwargs)
-    if advanced_file is None:
-        r = ctx.api_request('get', 'clusters/' +
-                            ctx.cluster + '/advancedConfig',
+    url = 'clusters/' + ctx.cluster + '/advancedConfig'
+    if delete:
+        r = ctx.api_request('delete', url)
+        click.echo(r.text)
+    elif advanced_file is None:
+        r = ctx.api_request('get', url,
                             headers={'Accept': '*/*'})
         click.echo(r.text)
     else:


### PR DESCRIPTION
Add `--delete` to `cluster config[-advanced]` to allow un-setting it once it's been set.

Also add a cleaner message when fetching an unset config.
