### PR TITLE
Fix framework arg

### DIFF
--- a/riak_mesos/cli.py
+++ b/riak_mesos/cli.py
@@ -25,6 +25,7 @@ from os.path import expanduser
 import click
 from dcos import config as dcos_config
 from dcos import errors as dcos_errors
+from dcos import subcommand as dcos_subcommand
 from dcos import http, marathon, mesos
 from kazoo.client import KazooClient
 
@@ -63,6 +64,12 @@ class RiakMesosDCOSStrategy(object):
         self._marathon_url = None
         self._framework_url = None
         self.ctx = ctx
+        self.framework = self.ctx.framework
+        # TODO Maybe we should pipe this back to self.ctx?
+        if self.framework is None:
+            # Grab argv, pump $0 via dcos.subcommand.noun to get the fw name
+            exe = sys.argv[0]
+            self.framework = dcos_subcommand.noun(exe)
         try:
             self.ctx.vlog('Attempting to create DCOSClient')
             dcos_client = mesos.DCOSClient()
@@ -85,7 +92,7 @@ class RiakMesosDCOSStrategy(object):
         if self._framework_url is not None:
             return self._framework_url
         # TODO: get framework name from dcos?
-        _framework_url = self.dcos_url + '/service/' + self.ctx.framework + '/'
+        _framework_url = self.dcos_url + '/service/' + self.framework + '/'
         r = self.ctx.http_request('get',
                                   _framework_url + 'healthcheck',
                                   False)

--- a/riak_mesos/cli.py
+++ b/riak_mesos/cli.py
@@ -64,13 +64,15 @@ class RiakMesosDCOSStrategy(object):
         self._marathon_url = None
         self._framework_url = None
         self.ctx = ctx
-        self.framework = self.ctx.framework
-        if self.framework is None:
-            # Grab argv, pump $0 via dcos.subcommand.noun to get the fw name
-            exe = sys.argv[0]
-            self.framework = dcos_subcommand.noun(exe)
-            self.ctx.framework = self.framework
         try:
+            if self.ctx.framework is None:
+                # Grab argv, pump $0 via dcos.subcommand.noun to get the fw name
+                exe = sys.argv[0]
+                self.framework = dcos_subcommand.noun(exe)
+                if self.framework is None:
+                    raise Exception("Unable to find Framework name")
+                # Update the context with our newly found FW name
+                self.ctx.framework = self.framework
             self.ctx.vlog('Attempting to create DCOSClient')
             dcos_client = mesos.DCOSClient()
             self.client = dcos_client

--- a/riak_mesos/cli.py
+++ b/riak_mesos/cli.py
@@ -246,7 +246,7 @@ class Context(object):
         # JSON Config (optional for dcos)
         self.config = None
         # Conditional options
-        self.framework = 'riak'
+        self.framework = None
         self.cluster = 'default'
         self.node = 'riak-default-1'
         self.timeout = 60
@@ -332,9 +332,10 @@ class Context(object):
 
         if framework is not None:
             self.framework = framework
-        _framework = self.config.get('framework-name')
-        if framework is None and _framework != '':
-            self.framework = _framework
+        if self.framework is None:
+            _framework = self.config.get('framework-name')
+            if framework is None and _framework != '':
+                self.framework = _framework
 
         if 'timeout' in kwargs and kwargs['timeout'] is not None:
             self.timeout = kwargs['timeout']

--- a/riak_mesos/cli.py
+++ b/riak_mesos/cli.py
@@ -65,11 +65,11 @@ class RiakMesosDCOSStrategy(object):
         self._framework_url = None
         self.ctx = ctx
         self.framework = self.ctx.framework
-        # TODO Maybe we should pipe this back to self.ctx?
         if self.framework is None:
             # Grab argv, pump $0 via dcos.subcommand.noun to get the fw name
             exe = sys.argv[0]
             self.framework = dcos_subcommand.noun(exe)
+            self.ctx.framework = self.framework
         try:
             self.ctx.vlog('Attempting to create DCOSClient')
             dcos_client = mesos.DCOSClient()

--- a/riak_mesos/cli.py
+++ b/riak_mesos/cli.py
@@ -66,7 +66,7 @@ class RiakMesosDCOSStrategy(object):
         self.ctx = ctx
         try:
             if self.ctx.framework is None:
-                # Grab argv, pump $0 via dcos.subcommand.noun to get the fw name
+                # Grab argv0, pump via dcos.subcommand.noun to get the fw name
                 exe = sys.argv[0]
                 self.framework = dcos_subcommand.noun(exe)
                 if self.framework is None:


### PR DESCRIPTION
This proposed change removes the default of `'riak'` for the `framework` name in the tools, and means that you can put the `--framework other` arg anywhere on the CLI and have it take effect (previously, if it was anywhere other than towards the end, it would be overridden by whatever was in the default config file.)

Do not yet merge, this needs proving out with DCOS.
