### PR TITLE
Allow split DC/OS KV and TS packages

### DIFF
--- a/riak_mesos/cli.py
+++ b/riak_mesos/cli.py
@@ -545,7 +545,7 @@ class RiakMesosCLI(click.MultiCommand):
         try:
             if sys.version_info[0] == 2:
                 name = name.encode('ascii', 'replace')
-            if name == "riak":
+            if name in ['riak', 'riak-ts', 'riak-kv']:
                 return cli
             mod = __import__('riak_mesos.commands.cmd_' + name,
                              None, None, ['cli'])

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -208,8 +208,10 @@ class RiakMesosConfig(object):
         return json.dumps(self.framework_marathon_json())
 
     def director_marathon_json(self, cluster):
+        framework = self.get('framework-name')
+        director_marathon_name = "-".join((framework, cluster, 'director'))
         director_marathon_conf = {
-            'id': '/' + cluster + '-director',
+            'id': '/' + director_marathon_name
             'cmd': './riak_mesos_director/bin/ermf-director',
             'cpus': self.get('director', 'cpus'),
             'mem': self.get('director', 'mem'),

--- a/riak_mesos/config.py
+++ b/riak_mesos/config.py
@@ -211,7 +211,7 @@ class RiakMesosConfig(object):
         framework = self.get('framework-name')
         director_marathon_name = "-".join((framework, cluster, 'director'))
         director_marathon_conf = {
-            'id': '/' + director_marathon_name
+            'id': '/' + director_marathon_name,
             'cmd': './riak_mesos_director/bin/ermf-director',
             'cpus': self.get('director', 'cpus'),
             'mem': self.get('director', 'mem'),

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,8 @@ setup(
     extras_require={
         'dev': ['check-manifest'],
         'test': ['coverage'],
+        'KV': [],
+        'TS': [],
     },
 
     # If there are data files included in your packages that need to be
@@ -114,8 +116,9 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
         'console_scripts': [
-            'riak-mesos=riak_mesos.cli:cli',
-            'dcos-riak=riak_mesos.cli:cli'
+            'dcos-riak-kv=riak_mesos.cli:cli [KV]',
+            'dcos-riak-ts=riak_mesos.cli:cli [TS]',
+            'riak-mesos=riak_mesos.cli:cli'
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -96,8 +96,6 @@ setup(
     extras_require={
         'dev': ['check-manifest'],
         'test': ['coverage'],
-        'KV': [],
-        'TS': [],
     },
 
     # If there are data files included in your packages that need to be
@@ -116,8 +114,6 @@ setup(
     # pip to create the appropriate form of executable for the target platform.
     entry_points={
         'console_scripts': [
-            'dcos-riak-kv=riak_mesos.cli:cli [KV]',
-            'dcos-riak-ts=riak_mesos.cli:cli [TS]',
             'riak-mesos=riak_mesos.cli:cli'
         ],
     },

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -4,7 +4,7 @@ from common import exec_command as _c
 
 
 def test_version():
-    c, o, e = _c(['dcos-riak', '--version'])
+    c, o, e = _c(['riak-mesos', '--version'])
     assert c == 0
     assert e == b''
 


### PR DESCRIPTION
- Don't create `dcos-riak` executable
- Allow the script to be run as any of `dcos riak|riak-ts|riak-kv`
