### PR TITLE
Bug fixes

### DIFF
--- a/riak_mesos/cli.py
+++ b/riak_mesos/cli.py
@@ -78,7 +78,7 @@ class RiakMesosDCOSStrategy(object):
             self.client = dcos_client
             dcos_url = self.client.get_dcos_url('')
             ssl_verify = dcos_config.get_config().get('core.ssl_verify')
-            self.ctx.vlog('DCOS core.ssl_verify value = ' + ssl_verify)
+            self.ctx.vlog('DCOS core.ssl_verify value = ' + str(ssl_verify))
             if ssl_verify is not None and (
                     not ssl_verify or ssl_verify == 'false'):
                 self.ctx.vlog('Setting insecure_ssl to True')

--- a/riak_mesos/commands/cmd_director.py
+++ b/riak_mesos/commands/cmd_director.py
@@ -45,6 +45,7 @@ def config(ctx, **kwargs):
 def wait_for_service(ctx, **kwargs):
     """Waits --timeout seconds or until director is running"""
     ctx.init_args(**kwargs)
+    ctx.config.from_marathon(ctx)
     timeout = ctx.timeout
     framework = ctx.framework
     app_name = "-".join((framework, ctx.cluster, 'director'))

--- a/riak_mesos/constants.py
+++ b/riak_mesos/constants.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """DCOS Riak Constants"""
 
-version = '1.3.1'
+version = '1.3.2'

--- a/riak_mesos/constants.py
+++ b/riak_mesos/constants.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """DCOS Riak Constants"""
 
-version = '1.3.0'
+version = '1.3.1'


### PR DESCRIPTION
3 cheeky fixes, largely unrelated:
- Wrap `ssl_verify` in `str()` to prevent error on concat with string
- Load config from marathon when doing `director wait-for-service` else `framework` won't be set
- Bump version string to `1.3.1` - maybe this should get bumped to 1.3.2 already?
