### PR TITLE
Pin dcos==0.4.11 for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'docopt',
-        'dcos',
+        'dcos>=0.4.6,<0.4.12',
         'kazoo',
         'click',
         'futures'


### PR DESCRIPTION
dcos==0.4.12 is python-3.4.x only - this will probably have to be the last real version of the tools that support python-2.7

Fixed #54 
